### PR TITLE
feat: implement owner admin module

### DIFF
--- a/config/integrations.json
+++ b/config/integrations.json
@@ -1,0 +1,11 @@
+{
+  "stripe": {
+    "enabled": true,
+    "webhookUrl": "/api/stripe/webhook"
+  },
+  "paddle": {
+    "enabled": false,
+    "vendorId": "",
+    "apiKey": ""
+  }
+}

--- a/config/pricing.json
+++ b/config/pricing.json
@@ -1,0 +1,18 @@
+{
+  "plans": [
+    {
+      "id": "free",
+      "name": "Free",
+      "price": 0,
+      "currency": "USD",
+      "features": ["Up to 3 team members", "Basic analytics"]
+    },
+    {
+      "id": "pro",
+      "name": "Pro",
+      "price": 49,
+      "currency": "USD",
+      "features": ["Unlimited team members", "Advanced analytics", "Priority support"]
+    }
+  ]
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { prisma } from "@lib/db";
+import { PlatformRole, UserStatus } from "@prisma/client";
+
+const SESSION_COOKIE_NAME = "msaas_session";
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (!pathname.startsWith("/admin")) {
+    return NextResponse.next();
+  }
+
+  const token = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  if (!token) {
+    return redirectToLogin(request);
+  }
+
+  const session = await prisma.authSession.findUnique({
+    where: { token },
+    include: { user: true },
+  });
+
+  if (!session) {
+    return redirectToLogin(request);
+  }
+
+  if (session.user.status !== UserStatus.ACTIVE) {
+    return redirectToLogin(request, true);
+  }
+
+  if (session.user.platformRole !== PlatformRole.ADMIN) {
+    return NextResponse.redirect(new URL("/app", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+function redirectToLogin(request: NextRequest, clearCookie = false) {
+  const response = NextResponse.redirect(new URL(`/sign-in?redirectTo=${encodeURIComponent("/admin")}`, request.url));
+  if (clearCookie) {
+    response.cookies.delete(SESSION_COOKIE_NAME);
+  }
+  return response;
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+  runtime: "nodejs",
+};

--- a/prisma/_modules.prisma
+++ b/prisma/_modules.prisma
@@ -1,33 +1,29 @@
 // source: modules/billing-stripe/prisma/schema.prisma
 model BillingSubscription {
-  id                String        @id @default(cuid())
-  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  organizationId    String        @unique
-  customerId        String
-  status            String
-  priceId           String
-  planTier          PlanTier      @default(PRO)
-  currentPeriodEnd  DateTime
-  cancelAtPeriodEnd Boolean       @default(false)
-  trialEndsAt       DateTime?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  id             String   @id @default(cuid())
+  userId         String
+  user           AuthUser @relation(fields: [userId], references: [id])
+  plan           String
+  status         String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 }
 
 // source: modules/auth/prisma/schema.prisma
 model AuthUser {
-  id              String                 @id @default(cuid())
-  email           String                 @unique
-  passwordHash    String
-  displayName     String?
+  id             String   @id @default(cuid())
+  email          String   @unique
+  passwordHash   String
+  displayName    String?
   emailVerifiedAt DateTime?
-  createdAt       DateTime               @default(now())
-  updatedAt       DateTime               @updatedAt
-  sessions        AuthSession[]
-  memberships     OrganizationMember[]
-  invitesSent     OrganizationInvite[]   @relation("InviteInvitedBy")
-  invitesAccepted OrganizationInvite[]   @relation("InviteAcceptedBy")
-  auditLogs       AuditLog[]             @relation("AuditLogActor")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  // Relations
+  sessions       AuthSession[]
+  invitesSent    Invite[] @relation("InviteInvitedBy")
+  invitesAccepted Invite[] @relation("InviteAcceptedBy")
+  auditLogs      AuditLog[] @relation("AuditLogActor")
 }
 
 model AuthSession {

--- a/prisma/merged.prisma
+++ b/prisma/merged.prisma
@@ -3,6 +3,49 @@
 
 generator client {
   provider = "prisma-client-js"
+
+}
+
+model BillingSubscription {
+  id                String        @id @default(cuid())
+  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  organizationId    String        @unique
+  customerId        String
+  status            String
+  priceId           String
+  planTier          PlanTier      @default(PRO)
+  currentPeriodEnd  DateTime
+  cancelAtPeriodEnd Boolean       @default(false)
+  trialEndsAt       DateTime?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+}
+
+model AuthUser {
+  id              String                 @id @default(cuid())
+  email           String                 @unique
+  passwordHash    String
+  displayName     String?
+  emailVerifiedAt DateTime?
+  platformRole    PlatformRole           @default(MEMBER)
+  status          UserStatus             @default(ACTIVE)
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
+  sessions        AuthSession[]
+  memberships     OrganizationMember[]
+  invitesSent     OrganizationInvite[]   @relation("InviteInvitedBy")
+  invitesAccepted OrganizationInvite[]   @relation("InviteAcceptedBy")
+  auditLogs       AuditLog[]             @relation("AuditLogActor")
+}
+
+model AuthSession {
+  id           String   @id @default(cuid())
+  token        String   @unique
+  user         AuthUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId       String
+  createdAt    DateTime @default(now())
+  lastActiveAt DateTime @default(now())
+  expiresAt    DateTime
 }
 
 datasource db {
@@ -15,11 +58,27 @@ enum PlanTier {
   PRO
 }
 
+enum PlatformRole {
+  MEMBER
+  ORG_ADMIN
+  ADMIN
+}
+
 enum MemberRole {
   OWNER
   ADMIN
   MEMBER
   VIEWER
+}
+
+enum OrganizationStatus {
+  ACTIVE
+  SUSPENDED
+}
+
+enum UserStatus {
+  ACTIVE
+  BLOCKED
 }
 
 enum MemberStatus {
@@ -56,6 +115,8 @@ model Organization {
   planTier                 PlanTier                @default(FREE)
   logoUrl                  String?
   primaryDomain            String?
+  status                   OrganizationStatus      @default(ACTIVE)
+  suspendedAt              DateTime?
   analyticsRetentionMonths Int                     @default(18)
   isOnboardingComplete     Boolean                 @default(false)
   createdAt                DateTime                @default(now())
@@ -246,34 +307,30 @@ model AuditLog {
 
 // source: modules/billing-stripe/prisma/schema.prisma
 model BillingSubscription {
-  id                String        @id @default(cuid())
-  organization      Organization  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  organizationId    String        @unique
-  customerId        String
-  status            String
-  priceId           String
-  planTier          PlanTier      @default(PRO)
-  currentPeriodEnd  DateTime
-  cancelAtPeriodEnd Boolean       @default(false)
-  trialEndsAt       DateTime?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  id             String   @id @default(cuid())
+  userId         String
+  user           AuthUser @relation(fields: [userId], references: [id])
+  plan           String
+  status         String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 }
 
 // source: modules/auth/prisma/schema.prisma
 model AuthUser {
-  id              String                 @id @default(cuid())
-  email           String                 @unique
-  passwordHash    String
-  displayName     String?
+  id             String   @id @default(cuid())
+  email          String   @unique
+  passwordHash   String
+  displayName    String?
   emailVerifiedAt DateTime?
-  createdAt       DateTime               @default(now())
-  updatedAt       DateTime               @updatedAt
-  sessions        AuthSession[]
-  memberships     OrganizationMember[]
-  invitesSent     OrganizationInvite[]   @relation("InviteInvitedBy")
-  invitesAccepted OrganizationInvite[]   @relation("InviteAcceptedBy")
-  auditLogs       AuditLog[]             @relation("AuditLogActor")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  // Relations
+  sessions       AuthSession[]
+  invitesSent    Invite[] @relation("InviteInvitedBy")
+  invitesAccepted Invite[] @relation("InviteAcceptedBy")
+  auditLogs      AuditLog[] @relation("AuditLogActor")
 }
 
 model AuthSession {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,8 @@ model AuthUser {
   passwordHash    String
   displayName     String?
   emailVerifiedAt DateTime?
+  platformRole    PlatformRole           @default(MEMBER)
+  status          UserStatus             @default(ACTIVE)
   createdAt       DateTime               @default(now())
   updatedAt       DateTime               @updatedAt
   sessions        AuthSession[]
@@ -53,11 +55,27 @@ enum PlanTier {
   PRO
 }
 
+enum PlatformRole {
+  MEMBER
+  ORG_ADMIN
+  ADMIN
+}
+
 enum MemberRole {
   OWNER
   ADMIN
   MEMBER
   VIEWER
+}
+
+enum OrganizationStatus {
+  ACTIVE
+  SUSPENDED
+}
+
+enum UserStatus {
+  ACTIVE
+  BLOCKED
 }
 
 enum MemberStatus {
@@ -94,6 +112,8 @@ model Organization {
   planTier                 PlanTier                @default(FREE)
   logoUrl                  String?
   primaryDomain            String?
+  status                   OrganizationStatus      @default(ACTIVE)
+  suspendedAt              DateTime?
   analyticsRetentionMonths Int                     @default(18)
   isOnboardingComplete     Boolean                 @default(false)
   createdAt                DateTime                @default(now())

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+
+import { AdminNav } from "@/components/admin/admin-nav";
+import { requireAdminUser } from "@/lib/server/admin-auth";
+
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  const user = await requireAdminUser();
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <div className="border-b bg-card/40 px-4 py-3 text-sm text-muted-foreground md:hidden">
+        Signed in as <span className="font-medium text-foreground">{user.email}</span>
+      </div>
+      <div className="flex flex-1">
+        <aside className="hidden w-64 border-r bg-card/40 p-6 md:block">
+          <div className="mb-6 space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">Owner admin</p>
+            <h1 className="text-xl font-semibold">Control center</h1>
+          </div>
+          <AdminNav />
+        </aside>
+        <main className="flex-1">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 p-6 md:px-10 md:py-10">
+            {children}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/logs/page.tsx
+++ b/src/app/admin/logs/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { prisma } from "@/lib/db";
+
+const PAGE_SIZE = 20;
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+async function resolveSearchParams(searchParams?: Promise<SearchParams>) {
+  if (!searchParams) {
+    return undefined;
+  }
+
+  return await searchParams;
+}
+
+function getPage(searchParams?: SearchParams) {
+  const value = searchParams?.page;
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = raw ? Number.parseInt(raw, 10) : 1;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+export default async function AdminLogsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const page = getPage(resolvedSearchParams);
+  const skip = (page - 1) * PAGE_SIZE;
+
+  const [logs, total] = await Promise.all([
+    prisma.auditLog.findMany({
+      include: { actor: true, organization: true },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: PAGE_SIZE,
+    }),
+    prisma.auditLog.count(),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">System logs</h1>
+        <p className="text-sm text-muted-foreground">
+          Review recent audit events across all organizations. Logs are paginated for faster navigation.
+        </p>
+      </header>
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Audit trail</CardTitle>
+            <CardDescription>
+              Showing page {page} of {totalPages}.
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline" size="sm" disabled={page <= 1}>
+              <Link href={`/admin/logs?page=${page - 1}`}>Previous</Link>
+            </Button>
+            <Button asChild variant="outline" size="sm" disabled={page >= totalPages}>
+              <Link href={`/admin/logs?page=${page + 1}`}>Next</Link>
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-4">
+            {logs.map((log) => (
+              <li key={log.id} className="rounded-lg border p-4 text-sm">
+                <div className="flex flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-foreground">{log.action}</span>
+                    <span className="text-xs text-muted-foreground">{log.organization.name}</span>
+                  </div>
+                  {log.description ? <p className="text-muted-foreground">{log.description}</p> : null}
+                  <p className="text-xs text-muted-foreground">
+                    {log.createdAt.toLocaleString()} • {log.actor?.email ?? "System"}
+                  </p>
+                </div>
+              </li>
+            ))}
+            {logs.length === 0 ? (
+              <li className="text-sm text-muted-foreground">No log entries found.</li>
+            ) : null}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/orgs/[orgId]/page.tsx
+++ b/src/app/admin/orgs/[orgId]/page.tsx
@@ -1,0 +1,155 @@
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { prisma } from "@/lib/db";
+import { updateOrganizationPlanAction, updateOrganizationStatusAction } from "../actions";
+import { OrganizationStatus, PlanTier } from "@prisma/client";
+
+type AdminOrganizationPageProps = {
+  params: Promise<{ orgId: string }>;
+};
+
+async function resolveParams(params: Promise<{ orgId: string }>) {
+  return params;
+}
+
+export default async function AdminOrganizationDetailPage(props: AdminOrganizationPageProps) {
+  const { orgId } = await resolveParams(props.params);
+  const organization = await prisma.organization.findUnique({
+    where: { id: orgId },
+    include: {
+      members: {
+        include: { user: true },
+        orderBy: { createdAt: "desc" },
+        take: 10,
+      },
+      auditLogs: {
+        orderBy: { createdAt: "desc" },
+        take: 5,
+        include: { actor: true },
+      },
+      subscriptions: true,
+    },
+  });
+
+  if (!organization) {
+    notFound();
+  }
+
+  const isSuspended = organization.status === OrganizationStatus.SUSPENDED;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{organization.name}</h1>
+        <p className="text-sm text-muted-foreground">Workspace slug: {organization.slug}</p>
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <Badge variant="outline">{organization.planTier} plan</Badge>
+          <Badge variant={isSuspended ? "destructive" : "secondary"}>{organization.status}</Badge>
+        </div>
+      </div>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-1">
+              <CardTitle>Status</CardTitle>
+              <CardDescription>Control availability and billing tier.</CardDescription>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <form action={updateOrganizationStatusAction}>
+                <input type="hidden" name="organizationId" value={organization.id} />
+                <input
+                  type="hidden"
+                  name="status"
+                  value={isSuspended ? OrganizationStatus.ACTIVE : OrganizationStatus.SUSPENDED}
+                />
+                <Button type="submit" variant={isSuspended ? "secondary" : "destructive"} size="sm">
+                  {isSuspended ? "Activate" : "Suspend"}
+                </Button>
+              </form>
+              <form action={updateOrganizationPlanAction} className="flex items-center gap-2">
+                <input type="hidden" name="organizationId" value={organization.id} />
+                <select
+                  name="planTier"
+                  defaultValue={organization.planTier}
+                  className="h-9 rounded-md border border-input bg-background px-2 text-xs"
+                >
+                  {Object.values(PlanTier).map((plan) => (
+                    <option key={plan} value={plan}>
+                      {plan}
+                    </option>
+                  ))}
+                </select>
+                <Button type="submit" size="sm" variant="outline">
+                  Update plan
+                </Button>
+              </form>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>Created {organization.createdAt.toDateString()}</p>
+            {organization.suspendedAt ? <p>Suspended {organization.suspendedAt.toDateString()}</p> : null}
+            <p>Members: {organization.members.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Recent activity</CardTitle>
+            <CardDescription>Latest audit events across the workspace.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-3 text-sm">
+              {organization.auditLogs.map((log) => (
+                <li key={log.id} className="space-y-1">
+                  <p className="font-medium text-foreground">{log.action}</p>
+                  {log.description ? <p className="text-muted-foreground">{log.description}</p> : null}
+                  <p className="text-xs text-muted-foreground">
+                    {log.createdAt.toLocaleString()} by {log.actor?.email ?? "System"}
+                  </p>
+                </li>
+              ))}
+              {organization.auditLogs.length === 0 ? (
+                <li className="text-sm text-muted-foreground">No audit events recorded.</li>
+              ) : null}
+            </ul>
+          </CardContent>
+        </Card>
+      </section>
+      <Card>
+        <CardHeader>
+          <CardTitle>Key members</CardTitle>
+          <CardDescription>Showing the 10 most recent members.</CardDescription>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[520px] text-sm">
+            <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="py-2 pr-4 font-medium">User</th>
+                <th className="px-4 py-2 font-medium">Role</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {organization.members.map((member) => (
+                <tr key={member.id}>
+                  <td className="py-3 pr-4">
+                    <div className="flex flex-col">
+                      <span className="font-medium">{member.user.displayName ?? member.user.email}</span>
+                      <span className="text-xs text-muted-foreground">{member.user.email}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Badge variant="outline">{member.role}</Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{member.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/orgs/actions.ts
+++ b/src/app/admin/orgs/actions.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { prisma } from "@/lib/db";
+import { requireAdminUser } from "@/lib/server/admin-auth";
+import { OrganizationStatus, PlanTier } from "@prisma/client";
+
+function parseOrganizationId(formData: FormData) {
+  const id = formData.get("organizationId");
+  if (typeof id !== "string" || !id) {
+    throw new Error("ORGANIZATION_ID_REQUIRED");
+  }
+  return id;
+}
+
+export async function updateOrganizationStatusAction(formData: FormData) {
+  await requireAdminUser();
+  const organizationId = parseOrganizationId(formData);
+  const statusValue = formData.get("status");
+  if (
+    typeof statusValue !== "string" ||
+    !Object.values(OrganizationStatus).includes(statusValue as OrganizationStatus)
+  ) {
+    throw new Error("INVALID_STATUS");
+  }
+  const status = statusValue as OrganizationStatus;
+
+  await prisma.organization.update({
+    where: { id: organizationId },
+    data: {
+      status,
+      suspendedAt: status === OrganizationStatus.SUSPENDED ? new Date() : null,
+    },
+  });
+
+  revalidatePath("/admin/orgs");
+  revalidatePath(`/admin/orgs/${organizationId}`);
+}
+
+export async function updateOrganizationPlanAction(formData: FormData) {
+  await requireAdminUser();
+  const organizationId = parseOrganizationId(formData);
+  const planValue = formData.get("planTier");
+  if (typeof planValue !== "string" || !Object.values(PlanTier).includes(planValue as PlanTier)) {
+    throw new Error("INVALID_PLAN");
+  }
+  const planTier = planValue as PlanTier;
+
+  await prisma.organization.update({
+    where: { id: organizationId },
+    data: { planTier },
+  });
+
+  revalidatePath("/admin/orgs");
+  revalidatePath(`/admin/orgs/${organizationId}`);
+}

--- a/src/app/admin/orgs/page.tsx
+++ b/src/app/admin/orgs/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { prisma } from "@/lib/db";
+import { updateOrganizationPlanAction, updateOrganizationStatusAction } from "./actions";
+import { OrganizationStatus, PlanTier } from "@prisma/client";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+async function resolveSearchParams(searchParams?: Promise<SearchParams>) {
+  if (!searchParams) {
+    return undefined;
+  }
+
+  return await searchParams;
+}
+
+function getSearchQuery(searchParams?: SearchParams) {
+  const value = searchParams?.q;
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
+}
+
+export default async function AdminOrganizationsPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const query = getSearchQuery(resolvedSearchParams);
+  const organizations = await prisma.organization.findMany({
+    where: query
+      ? {
+          OR: [
+            { name: { contains: query, mode: "insensitive" } },
+            { slug: { contains: query, mode: "insensitive" } },
+          ],
+        }
+      : undefined,
+    include: {
+      _count: { select: { members: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Organizations</h1>
+        <p className="text-sm text-muted-foreground">
+          Search, inspect, and administrate any workspace in the platform.
+        </p>
+      </header>
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Directory</CardTitle>
+            <CardDescription>{organizations.length} organizations</CardDescription>
+          </div>
+          <form className="w-full max-w-sm">
+            <Input name="q" defaultValue={query} placeholder="Search by name or slug" />
+          </form>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
+            <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="py-2 pr-4 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">Members</th>
+                <th className="px-4 py-2 font-medium">Plan</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {organizations.map((organization) => {
+                const isSuspended = organization.status === OrganizationStatus.SUSPENDED;
+                return (
+                  <tr key={organization.id} className="align-top">
+                    <td className="py-3 pr-4">
+                      <div className="flex flex-col">
+                        <Link href={`/admin/orgs/${organization.id}`} className="font-medium hover:underline">
+                          {organization.name}
+                        </Link>
+                        <span className="text-xs text-muted-foreground">{organization.slug}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">{organization._count.members}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant="outline">{organization.planTier}</Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={isSuspended ? "destructive" : "secondary"}>{organization.status}</Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-2">
+                        <form action={updateOrganizationStatusAction}>
+                          <input type="hidden" name="organizationId" value={organization.id} />
+                          <input
+                            type="hidden"
+                            name="status"
+                            value={isSuspended ? OrganizationStatus.ACTIVE : OrganizationStatus.SUSPENDED}
+                          />
+                          <Button type="submit" variant={isSuspended ? "secondary" : "destructive"} size="sm">
+                            {isSuspended ? "Activate" : "Suspend"}
+                          </Button>
+                        </form>
+                        <form action={updateOrganizationPlanAction} className="flex items-center gap-2">
+                          <input type="hidden" name="organizationId" value={organization.id} />
+                          <select
+                            name="planTier"
+                            defaultValue={organization.planTier}
+                            className="h-9 rounded-md border border-input bg-background px-2 text-xs"
+                          >
+                            {Object.values(PlanTier).map((plan) => (
+                              <option key={plan} value={plan}>
+                                {plan}
+                              </option>
+                            ))}
+                          </select>
+                          <Button type="submit" size="sm" variant="outline">
+                            Update
+                          </Button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,66 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getPlatformMetrics } from "@/lib/server/admin-dashboard";
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function formatPercent(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }).format(value);
+}
+
+export default async function AdminDashboardPage() {
+  const metrics = await getPlatformMetrics();
+
+  return (
+    <div className="flex flex-col gap-10">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-bold tracking-tight">Platform overview</h1>
+        <p className="text-base text-muted-foreground">
+          Monitor revenue, customer health, and administrative activity across your entire SaaS footprint.
+        </p>
+      </header>
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardDescription>Monthly recurring revenue</CardDescription>
+            <CardTitle className="text-3xl">{formatCurrency(metrics.mrr)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Active organizations</CardDescription>
+            <CardTitle className="text-3xl">{metrics.activeOrganizations}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Suspended organizations</CardDescription>
+            <CardTitle className="text-3xl">{metrics.suspendedOrganizations}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Active users</CardDescription>
+            <CardTitle className="text-3xl">{metrics.activeUsers}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Platform admins</CardDescription>
+            <CardTitle className="text-3xl">{metrics.admins}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardDescription>Churn rate</CardDescription>
+            <CardTitle className="text-3xl">{formatPercent(metrics.churnRate)}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Calculated as suspended organizations over total organizations this month.
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/payments/page.tsx
+++ b/src/app/admin/payments/page.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getPaymentsOverview, PaymentRecord } from "@/lib/server/payments";
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+function formatDate(date: Date) {
+  return date.toLocaleString();
+}
+
+function RecordsTable({ title, description, records }: { title: string; description: string; records: PaymentRecord[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        {records.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No records available.</p>
+        ) : (
+          <table className="w-full min-w-[640px] text-sm">
+            <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="py-2 pr-4 font-medium">Reference</th>
+                <th className="px-4 py-2 font-medium">Amount</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Customer</th>
+                <th className="px-4 py-2 font-medium">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {records.map((record) => (
+                <tr key={record.id}>
+                  <td className="py-3 pr-4">
+                    <div className="flex flex-col">
+                      <span className="font-medium">{record.id}</span>
+                      {record.description ? (
+                        <span className="text-xs text-muted-foreground">{record.description}</span>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">{formatCurrency(record.amount, record.currency)}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{record.status}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{record.customer ?? "-"}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{formatDate(record.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function AdminPaymentsPage() {
+  const overview = await getPaymentsOverview();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Payments</h1>
+        <p className="text-sm text-muted-foreground">
+          Review platform-wide payment activity and investigate customer billing events.
+        </p>
+      </header>
+      <RecordsTable title="Transactions" description="Latest payment intents or subscription renewals." records={overview.transactions} />
+      <RecordsTable title="Invoices" description="Recent invoices created for organizations." records={overview.invoices} />
+      <RecordsTable title="Refunds" description="Refunds issued to customers." records={overview.refunds} />
+    </div>
+  );
+}

--- a/src/app/admin/settings/actions.ts
+++ b/src/app/admin/settings/actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { requireAdminUser } from "@/lib/server/admin-auth";
+import {
+  getFeatureFlagsConfig,
+  getIntegrationConfig,
+  getPricingConfig,
+  updateFeatureFlag,
+  updateIntegrationConfig,
+  updatePricingConfig,
+} from "@/lib/server/platform-settings";
+
+export async function updatePlanAction(formData: FormData) {
+  await requireAdminUser();
+  const planId = formData.get("planId");
+  const name = formData.get("name");
+  const priceValue = formData.get("price");
+  const currency = formData.get("currency");
+
+  if (typeof planId !== "string" || !planId) {
+    throw new Error("PLAN_ID_REQUIRED");
+  }
+
+  if (typeof name !== "string" || !name) {
+    throw new Error("PLAN_NAME_REQUIRED");
+  }
+
+  const price = Number(priceValue);
+  if (!Number.isFinite(price) || price < 0) {
+    throw new Error("INVALID_PRICE");
+  }
+
+  const pricing = await getPricingConfig();
+  const plans = pricing.plans.map((plan) =>
+    plan.id === planId
+      ? {
+          ...plan,
+          name,
+          price,
+          currency:
+            typeof currency === "string" && currency ? currency.toUpperCase() : plan.currency,
+        }
+      : plan
+  );
+  await updatePricingConfig(plans);
+  revalidatePath("/admin/settings");
+}
+
+export async function toggleModuleAction(formData: FormData) {
+  await requireAdminUser();
+  const moduleKey = formData.get("moduleKey");
+  const enabledValue = formData.get("enabled");
+  if (typeof moduleKey !== "string" || !moduleKey) {
+    throw new Error("MODULE_KEY_REQUIRED");
+  }
+  const enabled = enabledValue === "true";
+  await updateFeatureFlag(moduleKey, enabled);
+  revalidatePath("/admin/settings");
+}
+
+export async function updateIntegrationAction(formData: FormData) {
+  await requireAdminUser();
+  const provider = formData.get("provider");
+  if (typeof provider !== "string" || !provider) {
+    throw new Error("PROVIDER_REQUIRED");
+  }
+
+  const payload: Record<string, unknown> = {};
+  formData.forEach((value, key) => {
+    if (key === "provider") {
+      return;
+    }
+    payload[key] = typeof value === "string" ? value : value.toString();
+  });
+
+  await updateIntegrationConfig(provider, payload);
+  revalidatePath("/admin/settings");
+}
+
+export async function refreshSettingsCache() {
+  await requireAdminUser();
+  await Promise.all([getFeatureFlagsConfig(), getPricingConfig(), getIntegrationConfig()]);
+  revalidatePath("/admin/settings");
+}

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,122 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  getFeatureFlagsConfig,
+  getIntegrationConfig,
+  getPricingConfig,
+} from "@/lib/server/platform-settings";
+import { refreshSettingsCache, toggleModuleAction, updateIntegrationAction, updatePlanAction } from "./actions";
+
+export default async function AdminSettingsPage() {
+  const [pricingConfig, featureConfig, integrations] = await Promise.all([
+    getPricingConfig(),
+    getFeatureFlagsConfig(),
+    getIntegrationConfig(),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Platform settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Configure pricing, feature flags, and payment integrations for the entire SaaS platform.
+        </p>
+      </header>
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Pricing plans</CardTitle>
+            <CardDescription>Update how plans are presented and billed.</CardDescription>
+          </div>
+          <form action={refreshSettingsCache}>
+            <Button type="submit" variant="outline" size="sm">
+              Refresh
+            </Button>
+          </form>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {pricingConfig.plans.map((plan) => (
+            <form key={plan.id} action={updatePlanAction} className="grid gap-4 rounded-lg border p-4 sm:grid-cols-5">
+              <input type="hidden" name="planId" value={plan.id} />
+              <div className="sm:col-span-2">
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Name
+                </label>
+                <Input name="name" defaultValue={plan.name} required />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Price
+                </label>
+                <Input name="price" type="number" min="0" step="0.01" defaultValue={plan.price} required />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Currency
+                </label>
+                <Input name="currency" defaultValue={plan.currency} required />
+              </div>
+              <div className="flex items-end justify-end">
+                <Button type="submit">Save</Button>
+              </div>
+              <div className="sm:col-span-5 text-xs text-muted-foreground">
+                Features: {plan.features.join(", ")}
+              </div>
+            </form>
+          ))}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Feature flags</CardTitle>
+          <CardDescription>Toggle modules on or off globally.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {Object.entries(featureConfig.modules).map(([moduleKey, module]) => (
+            <form key={moduleKey} action={toggleModuleAction} className="flex flex-wrap items-center justify-between gap-4 rounded-lg border p-4">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">{module.displayName}</h3>
+                <p className="text-xs text-muted-foreground">{module.description}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <input type="hidden" name="moduleKey" value={moduleKey} />
+                <input type="hidden" name="enabled" value={(!module.enabled).toString()} />
+                <Button type="submit" variant={module.enabled ? "destructive" : "secondary"}>
+                  {module.enabled ? "Disable" : "Enable"}
+                </Button>
+              </div>
+            </form>
+          ))}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Integrations</CardTitle>
+          <CardDescription>Manage credentials for billing providers.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {Object.entries(integrations).map(([provider, settings]) => (
+            <form key={provider} action={updateIntegrationAction} className="space-y-4 rounded-lg border p-4">
+              <input type="hidden" name="provider" value={provider} />
+              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">{provider}</h3>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {Object.entries(settings).map(([key, value]) => (
+                  <div key={key} className="space-y-1">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground" htmlFor={`${provider}-${key}`}>
+                      {key}
+                    </label>
+                    <Input id={`${provider}-${key}`} name={key} defaultValue={typeof value === "string" ? value : String(value ?? "")} />
+                  </div>
+                ))}
+              </div>
+              <div className="flex justify-end">
+                <Button type="submit">Save integration</Button>
+              </div>
+            </form>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/users/[userId]/page.tsx
+++ b/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,140 @@
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { prisma } from "@/lib/db";
+import { PlatformRole, UserStatus } from "@prisma/client";
+import {
+  impersonateUserAction,
+  resetUserPasswordAction,
+  updateUserRoleAction,
+  updateUserStatusAction,
+} from "../actions";
+
+type AdminUserPageProps = {
+  params: Promise<{ userId: string }>;
+};
+
+async function resolveParams(params: Promise<{ userId: string }>) {
+  return params;
+}
+
+export default async function AdminUserDetailPage(props: AdminUserPageProps) {
+  const { userId } = await resolveParams(props.params);
+  const user = await prisma.authUser.findUnique({
+    where: { id: userId },
+    include: {
+      memberships: {
+        include: {
+          organization: true,
+        },
+        orderBy: { createdAt: "desc" },
+      },
+    },
+  });
+
+  if (!user) {
+    notFound();
+  }
+
+  const isBlocked = user.status === UserStatus.BLOCKED;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{user.displayName ?? user.email}</h1>
+        <p className="text-sm text-muted-foreground">{user.email}</p>
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <Badge variant="outline">{user.platformRole}</Badge>
+          <Badge variant={isBlocked ? "destructive" : "secondary"}>{user.status}</Badge>
+        </div>
+      </header>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Account controls</CardTitle>
+            <CardDescription>Change status or role for this account.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <form action={updateUserStatusAction} className="flex flex-wrap gap-2">
+              <input type="hidden" name="userId" value={user.id} />
+              <input type="hidden" name="status" value={isBlocked ? UserStatus.ACTIVE : UserStatus.BLOCKED} />
+              <Button type="submit" variant={isBlocked ? "secondary" : "destructive"}>
+                {isBlocked ? "Unblock user" : "Block user"}
+              </Button>
+            </form>
+            <form action={updateUserRoleAction} className="flex flex-wrap items-center gap-2">
+              <input type="hidden" name="userId" value={user.id} />
+              <select
+                name="platformRole"
+                defaultValue={user.platformRole}
+                className="h-9 rounded-md border border-input bg-background px-2 text-xs"
+              >
+                {Object.values(PlatformRole).map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+              <Button type="submit" variant="outline">
+                Update role
+              </Button>
+            </form>
+            <form action={resetUserPasswordAction} className="flex flex-wrap items-center gap-2">
+              <input type="hidden" name="userId" value={user.id} />
+              <Input
+                name="newPassword"
+                type="password"
+                minLength={8}
+                required
+                placeholder="New password"
+                className="w-full sm:w-64"
+              />
+              <Button type="submit">Reset password</Button>
+            </form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Impersonation</CardTitle>
+            <CardDescription>Start a session as this user to debug their experience.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p className="text-muted-foreground">
+              A new session will be created for this user and you will be redirected to the workspace experience. Use cautiously
+              and remember to sign back in as an admin when finished.
+            </p>
+            <form action={impersonateUserAction}>
+              <input type="hidden" name="userId" value={user.id} />
+              <Button type="submit">Impersonate</Button>
+            </form>
+          </CardContent>
+        </Card>
+      </section>
+      <Card>
+        <CardHeader>
+          <CardTitle>Organization memberships</CardTitle>
+          <CardDescription>Organizations this user currently belongs to.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {user.memberships.length === 0 ? (
+            <p className="text-sm text-muted-foreground">This user is not a member of any organization.</p>
+          ) : (
+            <ul className="space-y-3 text-sm">
+              {user.memberships.map((membership) => (
+                <li key={membership.id} className="flex flex-col gap-1">
+                  <span className="font-medium text-foreground">{membership.organization.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    Role: {membership.role} • Status: {membership.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { prisma } from "@/lib/db";
+import { requireAdminUser } from "@/lib/server/admin-auth";
+import { PlatformRole, UserStatus } from "@prisma/client";
+import { createSession, setUserPassword } from "@modules/auth/lib/auth-service";
+
+function parseUserId(formData: FormData) {
+  const id = formData.get("userId");
+  if (typeof id !== "string" || !id) {
+    throw new Error("USER_ID_REQUIRED");
+  }
+  return id;
+}
+
+export async function updateUserStatusAction(formData: FormData) {
+  await requireAdminUser();
+  const userId = parseUserId(formData);
+  const statusValue = formData.get("status");
+  if (
+    typeof statusValue !== "string" ||
+    !Object.values(UserStatus).includes(statusValue as UserStatus)
+  ) {
+    throw new Error("INVALID_STATUS");
+  }
+  const status = statusValue as UserStatus;
+
+  await prisma.authUser.update({
+    where: { id: userId },
+    data: { status },
+  });
+
+  revalidatePath("/admin/users");
+  revalidatePath(`/admin/users/${userId}`);
+}
+
+export async function updateUserRoleAction(formData: FormData) {
+  await requireAdminUser();
+  const userId = parseUserId(formData);
+  const roleValue = formData.get("platformRole");
+  if (
+    typeof roleValue !== "string" ||
+    !Object.values(PlatformRole).includes(roleValue as PlatformRole)
+  ) {
+    throw new Error("INVALID_ROLE");
+  }
+  const platformRole = roleValue as PlatformRole;
+
+  await prisma.authUser.update({
+    where: { id: userId },
+    data: { platformRole },
+  });
+
+  revalidatePath("/admin/users");
+  revalidatePath(`/admin/users/${userId}`);
+}
+
+export async function resetUserPasswordAction(formData: FormData) {
+  await requireAdminUser();
+  const userId = parseUserId(formData);
+  const password = formData.get("newPassword");
+  if (typeof password !== "string" || password.length < 8) {
+    throw new Error("PASSWORD_TOO_SHORT");
+  }
+
+  await setUserPassword(userId, password);
+
+  revalidatePath(`/admin/users/${userId}`);
+}
+
+export async function impersonateUserAction(formData: FormData) {
+  await requireAdminUser();
+  const userId = parseUserId(formData);
+  await createSession(userId);
+  redirect("/app");
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { prisma } from "@/lib/db";
+import { PlatformRole, UserStatus } from "@prisma/client";
+import { updateUserRoleAction, updateUserStatusAction } from "./actions";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+async function resolveSearchParams(searchParams?: Promise<SearchParams>) {
+  if (!searchParams) {
+    return undefined;
+  }
+
+  return await searchParams;
+}
+
+function getSearchQuery(searchParams?: SearchParams) {
+  const value = searchParams?.q;
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
+}
+
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const resolvedSearchParams = await resolveSearchParams(searchParams);
+  const query = getSearchQuery(resolvedSearchParams);
+  const users = await prisma.authUser.findMany({
+    where: query
+      ? {
+          OR: [
+            { email: { contains: query, mode: "insensitive" } },
+            { displayName: { contains: query, mode: "insensitive" } },
+          ],
+        }
+      : undefined,
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Users</h1>
+        <p className="text-sm text-muted-foreground">
+          View every account, manage permissions, and act on behalf of end users.
+        </p>
+      </header>
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <CardTitle>Directory</CardTitle>
+            <CardDescription>{users.length} users</CardDescription>
+          </div>
+          <form className="w-full max-w-sm">
+            <Input name="q" defaultValue={query} placeholder="Search by email or name" />
+          </form>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-sm">
+            <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="py-2 pr-4 font-medium">User</th>
+                <th className="px-4 py-2 font-medium">Role</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Joined</th>
+                <th className="px-4 py-2 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {users.map((user) => {
+                const isBlocked = user.status === UserStatus.BLOCKED;
+                return (
+                  <tr key={user.id} className="align-top">
+                    <td className="py-3 pr-4">
+                      <div className="flex flex-col">
+                        <Link href={`/admin/users/${user.id}`} className="font-medium hover:underline">
+                          {user.displayName ?? user.email}
+                        </Link>
+                        <span className="text-xs text-muted-foreground">{user.email}</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <form action={updateUserRoleAction} className="flex items-center gap-2">
+                        <input type="hidden" name="userId" value={user.id} />
+                        <select
+                          name="platformRole"
+                          defaultValue={user.platformRole}
+                          className="h-9 rounded-md border border-input bg-background px-2 text-xs"
+                        >
+                          {Object.values(PlatformRole).map((role) => (
+                            <option key={role} value={role}>
+                              {role}
+                            </option>
+                          ))}
+                        </select>
+                        <Button type="submit" size="sm" variant="outline">
+                          Update
+                        </Button>
+                      </form>
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={isBlocked ? "destructive" : "secondary"}>{user.status}</Badge>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {user.createdAt.toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <form action={updateUserStatusAction}>
+                        <input type="hidden" name="userId" value={user.id} />
+                        <input
+                          type="hidden"
+                          name="status"
+                          value={isBlocked ? UserStatus.ACTIVE : UserStatus.BLOCKED}
+                        />
+                        <Button type="submit" size="sm" variant={isBlocked ? "secondary" : "destructive"}>
+                          {isBlocked ? "Unblock" : "Block"}
+                        </Button>
+                      </form>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/[orgSlug]/analytics/page.tsx
+++ b/src/app/app/[orgSlug]/analytics/page.tsx
@@ -5,13 +5,20 @@ import { getOrganizationAnalyticsSnapshot } from "@lib/server/analytics";
 import { markChecklistStep, getOrganizationBySlugForUser } from "@lib/server/organizations";
 import { getCurrentUser } from "@modules/auth/actions";
 
-export default async function AnalyticsPage({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+async function resolveParams(params: Params) {
+  return params;
+}
+
+export default async function AnalyticsPage({ params }: { params: Params }) {
+  const { orgSlug } = await resolveParams(params);
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
       <div className="flex flex-col items-center gap-6 text-center px-4">
         <h1 className="text-4xl font-bold">Simplify Your Links, Amplify Your Reach</h1>
         <p className="text-lg text-muted-foreground max-w-2xl">
-          Our app makes it easy to shorten, manage, and track your links. Whether you're a marketer, business owner, or content creator, our platform helps you maximize your impact with powerful analytics and seamless sharing.
+          Our app makes it easy to shorten, manage, and track your links. Whether you&apos;re a marketer, business owner, or content creator, our platform helps you maximize your impact with powerful analytics and seamless sharing.
         </p>
         <div className="flex gap-4">
           <Button>

--- a/src/components/admin/admin-nav.tsx
+++ b/src/components/admin/admin-nav.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+const NAV_ITEMS = [
+  { href: "/admin", label: "Dashboard" },
+  { href: "/admin/orgs", label: "Organizations" },
+  { href: "/admin/users", label: "Users" },
+  { href: "/admin/payments", label: "Payments" },
+  { href: "/admin/settings", label: "Settings" },
+  { href: "/admin/logs", label: "Logs" },
+];
+
+export function AdminNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-col gap-1">
+      {NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            )}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { getCurrentUser } from "@modules/auth/actions";
+import { PlatformRole } from "@prisma/client";
+
+export async function requireAdminUser() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect(`/sign-in?redirectTo=${encodeURIComponent("/admin")}`);
+  }
+
+  if (user.platformRole !== PlatformRole.ADMIN) {
+    redirect("/app");
+  }
+
+  return user;
+}

--- a/src/lib/server/admin-dashboard.ts
+++ b/src/lib/server/admin-dashboard.ts
@@ -1,0 +1,43 @@
+import { PlatformRole, OrganizationStatus, UserStatus } from "@prisma/client";
+
+import { prisma } from "@lib/db";
+
+import { getPricingConfig } from "./platform-settings";
+
+export type PlatformMetrics = {
+  mrr: number;
+  activeOrganizations: number;
+  suspendedOrganizations: number;
+  activeUsers: number;
+  churnRate: number;
+  admins: number;
+};
+
+export async function getPlatformMetrics(): Promise<PlatformMetrics> {
+  const [pricingConfig, organizations, users, subscriptions] = await Promise.all([
+    getPricingConfig(),
+    prisma.organization.findMany({ select: { status: true } }),
+    prisma.authUser.findMany({ select: { status: true, platformRole: true } }),
+    prisma.billingSubscription.findMany({ select: { planTier: true } }),
+  ]);
+
+  const planPriceMap = new Map<string, number>();
+  pricingConfig.plans.forEach((plan) => {
+    planPriceMap.set(plan.id.toUpperCase(), plan.price);
+  });
+
+  const mrr = subscriptions.reduce((total, subscription) => {
+    const key = subscription.planTier.toString();
+    return total + (planPriceMap.get(key) ?? 0);
+  }, 0);
+
+  const totalOrganizations = organizations.length;
+  const activeOrganizations = organizations.filter((org) => org.status === OrganizationStatus.ACTIVE).length;
+  const suspendedOrganizations = organizations.filter((org) => org.status === OrganizationStatus.SUSPENDED).length;
+  const activeUsers = users.filter((user) => user.status === UserStatus.ACTIVE).length;
+  const admins = users.filter((user) => user.platformRole === PlatformRole.ADMIN).length;
+
+  const churnRate = totalOrganizations === 0 ? 0 : suspendedOrganizations / totalOrganizations;
+
+  return { mrr, activeOrganizations, suspendedOrganizations, activeUsers, churnRate, admins };
+}

--- a/src/lib/server/payments.ts
+++ b/src/lib/server/payments.ts
@@ -1,0 +1,125 @@
+import { prisma } from "@/lib/db";
+import { getPricingConfig } from "./platform-settings";
+
+export type PaymentRecord = {
+  id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  createdAt: Date;
+  customer?: string;
+  description?: string;
+};
+
+export type PaymentsOverview = {
+  transactions: PaymentRecord[];
+  invoices: PaymentRecord[];
+  refunds: PaymentRecord[];
+};
+
+const STRIPE_API_BASE = "https://api.stripe.com/v1";
+
+async function fetchStripe(endpoint: string, apiKey: string) {
+  const response = await fetch(`${STRIPE_API_BASE}${endpoint}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Stripe API error: ${response.status}`);
+  }
+
+  return (await response.json()) as { data?: StripeResource[] };
+}
+
+type StripeResource = {
+  id: string;
+  amount?: number;
+  amount_paid?: number;
+  amount_refunded?: number;
+  currency?: string;
+  status?: string;
+  created?: number;
+  customer?: string;
+  description?: string;
+};
+
+function convertStripeRecords(records: StripeResource[] | undefined): PaymentRecord[] {
+  if (!records) {
+    return [];
+  }
+  return records.map((record) => ({
+    id: record.id,
+    amount: (record.amount_paid ?? record.amount ?? record.amount_refunded ?? 0) / 100,
+    currency: (record.currency ?? "usd").toUpperCase(),
+    status: record.status ?? "unknown",
+    createdAt: new Date((record.created ?? 0) * 1000),
+    customer: record.customer,
+    description: record.description,
+  }));
+}
+
+async function buildFallbackPayments(): Promise<PaymentsOverview> {
+  const [pricingConfig, subscriptions] = await Promise.all([
+    getPricingConfig(),
+    prisma.billingSubscription.findMany({
+      include: { organization: { select: { name: true } } },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+  const planPriceMap = new Map<string, { amount: number; currency: string }>();
+  pricingConfig.plans.forEach((plan) => {
+    planPriceMap.set(plan.id.toUpperCase(), { amount: plan.price, currency: plan.currency });
+  });
+
+  const transactions = subscriptions.map((subscription) => {
+    const plan = planPriceMap.get(subscription.planTier.toString()) ?? { amount: 0, currency: "USD" };
+    return {
+      id: subscription.id,
+      amount: plan.amount,
+      currency: plan.currency,
+      status: subscription.status,
+      createdAt: subscription.createdAt,
+      customer: subscription.customerId,
+      description: `${subscription.organization.name} • ${subscription.planTier} plan`,
+    } satisfies PaymentRecord;
+  });
+
+  return {
+    transactions,
+    invoices: transactions,
+    refunds: [],
+  };
+}
+
+export async function getPaymentsOverview(): Promise<PaymentsOverview> {
+  const stripeApiKey = process.env.STRIPE_SECRET_KEY || process.env.STRIPE_API_KEY;
+  if (!stripeApiKey) {
+    return buildFallbackPayments();
+  }
+
+  try {
+    const [charges, invoices, refunds] = await Promise.all([
+      fetchStripe("/payment_intents?limit=10", stripeApiKey),
+      fetchStripe("/invoices?limit=10", stripeApiKey),
+      fetchStripe("/refunds?limit=10", stripeApiKey),
+    ]);
+
+    const overview: PaymentsOverview = {
+      transactions: convertStripeRecords(charges.data),
+      invoices: convertStripeRecords(invoices.data),
+      refunds: convertStripeRecords(refunds.data),
+    };
+
+    if (overview.transactions.length === 0 && overview.invoices.length === 0 && overview.refunds.length === 0) {
+      return buildFallbackPayments();
+    }
+
+    return overview;
+  } catch (error) {
+    console.error("Failed to fetch Stripe data", error);
+    return buildFallbackPayments();
+  }
+}

--- a/src/lib/server/platform-settings.ts
+++ b/src/lib/server/platform-settings.ts
@@ -1,0 +1,73 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const rootDir = process.cwd();
+const featuresPath = path.join(rootDir, "config", "features.json");
+const pricingPath = path.join(rootDir, "config", "pricing.json");
+const integrationsPath = path.join(rootDir, "config", "integrations.json");
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const data = await readFile(filePath, "utf8");
+  return JSON.parse(data) as T;
+}
+
+async function writeJsonFile<T>(filePath: string, data: T): Promise<void> {
+  await writeFile(filePath, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+export type PricingPlan = {
+  id: string;
+  name: string;
+  price: number;
+  currency: string;
+  features: string[];
+};
+
+export type PricingConfig = {
+  plans: PricingPlan[];
+};
+
+export async function getPricingConfig(): Promise<PricingConfig> {
+  return readJsonFile<PricingConfig>(pricingPath);
+}
+
+export async function updatePricingConfig(plans: PricingPlan[]): Promise<PricingConfig> {
+  const nextConfig: PricingConfig = { plans };
+  await writeJsonFile(pricingPath, nextConfig);
+  return nextConfig;
+}
+
+export type FeatureFlagsConfig = {
+  modules: Record<string, { enabled: boolean; displayName: string; description: string }>;
+  billing: { provider: string };
+};
+
+export async function getFeatureFlagsConfig(): Promise<FeatureFlagsConfig> {
+  return readJsonFile<FeatureFlagsConfig>(featuresPath);
+}
+
+export async function updateFeatureFlag(moduleKey: string, enabled: boolean): Promise<FeatureFlagsConfig> {
+  const config = await getFeatureFlagsConfig();
+  if (!config.modules[moduleKey]) {
+    throw new Error(`MODULE_NOT_FOUND:${moduleKey}`);
+  }
+  config.modules[moduleKey].enabled = enabled;
+  await writeJsonFile(featuresPath, config);
+  return config;
+}
+
+export type IntegrationConfig = Record<string, Record<string, unknown>>;
+
+export async function getIntegrationConfig(): Promise<IntegrationConfig> {
+  return readJsonFile<IntegrationConfig>(integrationsPath);
+}
+
+export async function updateIntegrationConfig(provider: string, payload: Record<string, unknown>): Promise<IntegrationConfig> {
+  const config = await getIntegrationConfig();
+  if (!config[provider]) {
+    throw new Error(`INTEGRATION_NOT_FOUND:${provider}`);
+  }
+  config[provider] = { ...config[provider], ...payload };
+  await writeJsonFile(integrationsPath, config);
+  return config;
+}


### PR DESCRIPTION
## Summary
- add the owner admin area with dashboard, organizations, users, payments, settings, and logs routes under /admin
- extend authentication with platform roles and statuses, add admin-only middleware, and expose supporting server utilities
- introduce configurable pricing, feature, and integration settings plus payment reporting backed by Prisma updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfe7c92b80832ba0c71473200a7b53