### PR TITLE
Fix Next.js build regressions from async params

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -31,7 +31,7 @@ export async function middleware(request: NextRequest) {
     return redirectToLogin(request, true);
   }
 
-  const allowedPlatformRoles = [PlatformRole.ADMIN, PlatformRole.SUPER_ADMIN];
+  const allowedPlatformRoles: PlatformRole[] = [PlatformRole.ADMIN, PlatformRole.SUPER_ADMIN];
 
   if (!allowedPlatformRoles.includes(session.user.platformRole)) {
     return NextResponse.redirect(new URL("/app", request.url));

--- a/src/app/app/[orgSlug]/layout.tsx
+++ b/src/app/app/[orgSlug]/layout.tsx
@@ -5,16 +5,19 @@ import { AppShell } from "@components/app/app-shell";
 import { getOrganizationsForUser, getOrganizationBySlugForUser } from "@lib/server/organizations";
 import { getCurrentUser } from "@modules/auth/actions";
 
+type Params = Promise<{ orgSlug: string }>;
+
 export default async function OrganizationLayout({
   children,
   params,
 }: {
   children: ReactNode;
-  params: { orgSlug: string };
+  params: Params;
 }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
-    redirect(`/sign-in?redirectTo=${encodeURIComponent(`/app/${params.orgSlug}`)}`);
+    redirect(`/sign-in?redirectTo=${encodeURIComponent(`/app/${orgSlug}`)}`);
   }
 
   const memberships = await getOrganizationsForUser(user.id);
@@ -22,7 +25,7 @@ export default async function OrganizationLayout({
     redirect("/app/new");
   }
 
-  const active = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const active = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!active) {
     notFound();
   }

--- a/src/app/app/[orgSlug]/links/page.tsx
+++ b/src/app/app/[orgSlug]/links/page.tsx
@@ -11,13 +11,16 @@ import { getLinkAnalyticsSummary, computeUsageStats, getPlanLimits } from "@lib/
 import { getOrganizationBySlugForUser } from "@lib/server/organizations";
 import { getCurrentUser } from "@modules/auth/actions";
 
-export default async function OrganizationOverview({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function OrganizationOverview({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -125,14 +128,14 @@ export default async function OrganizationOverview({ params }: { params: { orgSl
             {analytics.topLinks.length ? (
               <ul className="space-y-3">
                 {analytics.topLinks.map((item) => (
-                  <li key={item.linkId} className="flex items-center justify-between gap-4 rounded border border-border/60 p-3">
+                  <li key={item.id} className="flex items-center justify-between gap-4 rounded border border-border/60 p-3">
                     <div className="flex flex-col">
                       <span className="text-sm font-medium">{item.slug}</span>
                       <span className="truncate text-xs text-muted-foreground">{item.destinationUrl}</span>
                     </div>
                     <div className="flex items-center gap-3 text-sm text-muted-foreground">
                       <span>
-                        <strong className="text-foreground">{item.value}</strong> clicks
+                        <strong className="text-foreground">{item.clickCount}</strong> clicks
                       </span>
                     </div>
                   </li>

--- a/src/app/app/[orgSlug]/page.tsx
+++ b/src/app/app/[orgSlug]/page.tsx
@@ -12,13 +12,16 @@ import { getCurrentUser } from "@modules/auth/actions";
 
 import { CreateLinkForm } from "./links/create-link-form";
 
-export default async function LinksHome({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function LinksHome({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -27,7 +30,7 @@ export default async function LinksHome({ params }: { params: { orgSlug: string 
 
   return (
     <div className="flex flex-col gap-6">
-      <CreateLinkForm organizationSlug={params.orgSlug} />
+      <CreateLinkForm organizationSlug={orgSlug} />
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
@@ -35,7 +38,7 @@ export default async function LinksHome({ params }: { params: { orgSlug: string 
             <CardDescription>Manage slugs, update destinations, and monitor performance.</CardDescription>
           </div>
           <Button asChild variant="outline" size="sm">
-            <Link href={`/app/${params.orgSlug}/analytics`}>View analytics</Link>
+            <Link href={`/app/${orgSlug}/analytics`}>View analytics</Link>
           </Button>
         </CardHeader>
         <CardContent>

--- a/src/app/app/[orgSlug]/settings/actions.ts
+++ b/src/app/app/[orgSlug]/settings/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 import { updateOrganizationSettings, softDeleteOrganization, getOrganizationBySlugForUser } from "@lib/server/organizations";
 import { getCurrentUser } from "@modules/auth/actions";

--- a/src/app/app/[orgSlug]/settings/api-keys/page.tsx
+++ b/src/app/app/[orgSlug]/settings/api-keys/page.tsx
@@ -11,13 +11,16 @@ import { getCurrentUser } from "@modules/auth/actions";
 import { CreateApiKeyForm } from "./api-key-form";
 import { revokeApiKeyAction } from "./actions";
 
-export default async function ApiKeysSettingsPage({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function ApiKeysSettingsPage({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -32,7 +35,7 @@ export default async function ApiKeysSettingsPage({ params }: { params: { orgSlu
           Generate scoped API access tokens for integrations and automation.
         </p>
       </div>
-      <CreateApiKeyForm organizationSlug={params.orgSlug} />
+      <CreateApiKeyForm organizationSlug={orgSlug} />
       <Card>
         <CardHeader>
           <CardTitle>Existing keys</CardTitle>
@@ -55,7 +58,7 @@ export default async function ApiKeysSettingsPage({ params }: { params: { orgSlu
                     {key.revokedAt ? <Badge variant="destructive">Revoked</Badge> : <Badge variant="outline">Active</Badge>}
                     {!key.revokedAt ? (
                       <form action={revokeApiKeyAction}>
-                        <input type="hidden" name="organizationSlug" value={params.orgSlug} />
+                        <input type="hidden" name="organizationSlug" value={orgSlug} />
                         <input type="hidden" name="apiKeyId" value={key.id} />
                         <Button type="submit" variant="ghost" size="sm">
                           Revoke

--- a/src/app/app/[orgSlug]/settings/billing/page.tsx
+++ b/src/app/app/[orgSlug]/settings/billing/page.tsx
@@ -6,13 +6,16 @@ import { getBillingOverview } from "@lib/server/billing";
 import { getOrganizationBySlugForUser } from "@lib/server/organizations";
 import { getCurrentUser } from "@modules/auth/actions";
 
-export default async function BillingSettingsPage({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function BillingSettingsPage({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }

--- a/src/app/app/[orgSlug]/settings/domains/page.tsx
+++ b/src/app/app/[orgSlug]/settings/domains/page.tsx
@@ -11,6 +11,8 @@ import { getCurrentUser } from "@modules/auth/actions";
 import { deleteDomainAction } from "./actions";
 import { DomainRequestForm } from "./domain-form";
 
+type Params = Promise<{ orgSlug: string }>;
+
 const STATUS_COPY: Record<string, string> = {
   PENDING: "Pending verification",
   VERIFYING: "Verifying",
@@ -18,13 +20,14 @@ const STATUS_COPY: Record<string, string> = {
   FAILED: "Verification failed",
 };
 
-export default async function DomainsSettingsPage({ params }: { params: { orgSlug: string } }) {
+export default async function DomainsSettingsPage({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -39,7 +42,7 @@ export default async function DomainsSettingsPage({ params }: { params: { orgSlu
           Map branded domains to your short links. Pro plans support up to three custom domains.
         </p>
       </div>
-      <DomainRequestForm organizationSlug={params.orgSlug} />
+      <DomainRequestForm organizationSlug={orgSlug} />
       <Card>
         <CardHeader>
           <CardTitle>Active domains</CardTitle>
@@ -62,7 +65,7 @@ export default async function DomainsSettingsPage({ params }: { params: { orgSlu
                   <div className="flex items-center gap-3">
                     <Badge variant="outline">{STATUS_COPY[domain.status] ?? domain.status}</Badge>
                     <form action={deleteDomainAction}>
-                      <input type="hidden" name="organizationSlug" value={params.orgSlug} />
+                      <input type="hidden" name="organizationSlug" value={orgSlug} />
                       <input type="hidden" name="domainId" value={domain.id} />
                       <Button type="submit" variant="ghost" size="sm">
                         Remove

--- a/src/app/app/[orgSlug]/settings/members/page.tsx
+++ b/src/app/app/[orgSlug]/settings/members/page.tsx
@@ -11,13 +11,16 @@ import { getCurrentUser } from "@modules/auth/actions";
 import { InviteMemberForm } from "./invite-form";
 import { revokeInviteAction } from "./actions";
 
-export default async function MembersSettingsPage({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function MembersSettingsPage({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -49,7 +52,7 @@ export default async function MembersSettingsPage({ params }: { params: { orgSlu
         <h1 className="text-2xl font-semibold">Workspace members</h1>
         <p className="text-sm text-muted-foreground">Invite teammates and manage access levels.</p>
       </div>
-      <InviteMemberForm organizationSlug={params.orgSlug} />
+      <InviteMemberForm organizationSlug={orgSlug} />
       <Card>
         <CardHeader>
           <CardTitle>Team members</CardTitle>
@@ -103,7 +106,7 @@ export default async function MembersSettingsPage({ params }: { params: { orgSlu
                   </div>
                   <form action={revokeInviteAction}>
                     <input type="hidden" name="inviteId" value={invite.id} />
-                    <input type="hidden" name="organizationSlug" value={params.orgSlug} />
+                    <input type="hidden" name="organizationSlug" value={orgSlug} />
                     <Button type="submit" variant="ghost" size="sm">
                       Revoke
                     </Button>

--- a/src/app/app/[orgSlug]/settings/page.tsx
+++ b/src/app/app/[orgSlug]/settings/page.tsx
@@ -8,13 +8,16 @@ import { getCurrentUser } from "@modules/auth/actions";
 import { deleteOrganizationAction } from "./actions";
 import { OrganizationProfileForm } from "./profile-form";
 
-export default async function OrganizationSettingsPage({ params }: { params: { orgSlug: string } }) {
+type Params = Promise<{ orgSlug: string }>;
+
+export default async function OrganizationSettingsPage({ params }: { params: Params }) {
+  const { orgSlug } = await params;
   const user = await getCurrentUser();
   if (!user) {
     return null;
   }
 
-  const access = await getOrganizationBySlugForUser(params.orgSlug, user.id);
+  const access = await getOrganizationBySlugForUser(orgSlug, user.id);
   if (!access) {
     return null;
   }
@@ -29,7 +32,7 @@ export default async function OrganizationSettingsPage({ params }: { params: { o
           <p className="text-sm text-muted-foreground">Update the public name and default metadata for this workspace.</p>
         </div>
         <OrganizationProfileForm
-          organizationSlug={params.orgSlug}
+          organizationSlug={orgSlug}
           defaultName={access.organization.name}
           defaultPrimaryDomain={access.organization.primaryDomain ?? null}
         />
@@ -45,7 +48,7 @@ export default async function OrganizationSettingsPage({ params }: { params: { o
           </CardContent>
           <CardFooter>
             <Button asChild variant="outline" size="sm">
-              <a href={`/app/${params.orgSlug}/settings/billing`}>Open billing</a>
+              <a href={`/app/${orgSlug}/settings/billing`}>Open billing</a>
             </Button>
           </CardFooter>
         </Card>
@@ -62,7 +65,7 @@ export default async function OrganizationSettingsPage({ params }: { params: { o
               </AlertDescription>
             </Alert>
             <form action={deleteOrganizationAction} className="flex flex-col gap-3">
-              <input type="hidden" name="organizationSlug" value={params.orgSlug} />
+              <input type="hidden" name="organizationSlug" value={orgSlug} />
               <Button type="submit" variant="destructive" disabled={!canDelete}>
                 Delete workspace
               </Button>

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -40,7 +40,7 @@ const NAV_ITEMS: { heading: string; items: NavItem[] }[] = [
 
 export function AppSidebar() {
   const pathname = usePathname();
-  const { organization } = useActiveOrganization() as { organization: { slug: string; membership: { role: MemberRole } } };
+  const { organization, membership } = useActiveOrganization();
 
   return (
     <nav className="hidden w-64 flex-col border-r border-border/60 bg-background/40 p-6 lg:flex">
@@ -61,7 +61,7 @@ export function AppSidebar() {
                 [MemberRole.VIEWER]: 0,
               };
               const required = item.minRole ? roleOrder[item.minRole] : 0;
-              const current = roleOrder[organization?.membership?.role];
+              const current = roleOrder[membership.role];
               if (current < required) {
                 return null;
               }

--- a/src/lib/server/admin-auth.ts
+++ b/src/lib/server/admin-auth.ts
@@ -10,7 +10,9 @@ export async function requireAdminUser() {
     redirect(`/sign-in?${params.toString()}`);
   }
 
-  if (![PlatformRole.ADMIN, PlatformRole.SUPER_ADMIN].includes(user.platformRole)) {
+  const allowedRoles: PlatformRole[] = [PlatformRole.ADMIN, PlatformRole.SUPER_ADMIN];
+
+  if (!allowedRoles.includes(user.platformRole)) {
     redirect("/app");
   }
 

--- a/src/lib/server/links.ts
+++ b/src/lib/server/links.ts
@@ -463,10 +463,12 @@ export async function getLinkAnalyticsSummary({ organizationId, from, to }: Anal
   ]);
 
   const totalClicks = totals.reduce((sum, item) => sum + item._count._all, 0);
+  const uniqueVisitors = links.reduce((sum, item) => sum + item.uniqueVisitors, 0);
 
   return {
     topLinks: links,
     totalClicks,
+    uniqueVisitors,
   };
 }
 

--- a/src/lib/server/organizations.ts
+++ b/src/lib/server/organizations.ts
@@ -73,8 +73,6 @@ export async function createOrganizationWithOwner({
   });
 }
 
-type MembershipSummary = Awaited<ReturnType<typeof getOrganizationsForUser>>[number];
-
 export async function getOrganizationsForUser(userId: string) {
   const memberships = await prisma.organizationMember.findMany({
     where: {
@@ -99,8 +97,6 @@ export async function getOrganizationsForUser(userId: string) {
     membership,
   }));
 }
-
-type OrganizationAccess = NonNullable<Awaited<ReturnType<typeof getOrganizationBySlugForUser>>>;
 
 export async function getOrganizationBySlugForUser(slug: string, userId: string) {
   const organization = await prisma.organization.findFirst({
@@ -225,11 +221,11 @@ export async function markChecklistStep(organizationId: string, step: ChecklistS
   });
 }
 
-export function isOwnerOrAdmin(membership: MembershipSummary["membership"]) {
+export function isOwnerOrAdmin(membership: { role: MemberRole }) {
   return membership.role === MemberRole.OWNER || membership.role === MemberRole.ADMIN;
 }
 
-export function assertCanManageBilling(membership: OrganizationAccess["membership"]) {
+export function assertCanManageBilling(membership: { role: MemberRole }) {
   if (!isOwnerOrAdmin(membership)) {
     throw new Error("FORBIDDEN_BILLING_ACCESS");
   }

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -10,6 +10,6 @@ export async function ensureApplicationIsReachable(
     await request.get(BASE_URL, { timeout: 5_000, failOnStatusCode: false });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
-    test.skip(`${contextLabel} requires a running application at ${BASE_URL}. ${reason}`);
+    test.skip(true, `${contextLabel} requires a running application at ${BASE_URL}. ${reason}`);
   }
 }


### PR DESCRIPTION
## Summary
- await Next.js App Router params across organization layouts, pages, and route handlers to match the v15 typing changes
- surface aggregate unique visitor counts in link analytics and update the overview UI to read the new fields
- relax role checks, admin middleware, and test helpers to satisfy stricter TypeScript guards in the build

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee18197a94832badcdd30b219aeed0